### PR TITLE
Properly mark Encoder as available when StreamEncoder is closed

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -309,6 +309,7 @@ func TestEncoder_Stream(t *testing.T) {
 
 	err = streamEncoder.Close()
 	require.NoError(t, err)
+	require.False(t, encoder.begin)
 
 	require.NoError(t, encoder.Close())
 

--- a/stream_encoder.go
+++ b/stream_encoder.go
@@ -330,5 +330,6 @@ func (s *StreamEncoder) Close() error {
 		return err
 	}
 	_, err = s.encoder.writer.SeekPos(finalPos)
+	s.encoder.begin = false
 	return err
 }


### PR DESCRIPTION
We should mark the `begin` field as `false` when a collection encoder is closed. Otherwise, the encoder does not allow the initialization of a new collection encoder, since one is already active.