### PR TITLE
Support Redis Functions in RDB

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -207,6 +207,16 @@ func (s *FileEncoder) WriteJSON(key string, json string, expiry time.Time) error
 	return nil
 }
 
+func (s *FileEncoder) WriteLibrary(code string) error {
+	if s.begin {
+		return fmt.Errorf("cannot write; a collection is already being written. Call Close on the existing collection first")
+	}
+	if err := s.writer.WriteByte(byte(typeOpCodeFunction2)); err != nil {
+		return err
+	}
+	return s.writeString(code)
+}
+
 func (s *FileEncoder) Close() error {
 	err := s.writeEOF()
 	if err != nil {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,11 +1,12 @@
 package rdb
 
 import (
-	"github.com/stretchr/testify/require"
 	"math"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const version = "7.2.4"
@@ -359,4 +360,38 @@ func TestEncoder_JSON(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, db.modules[jsonKey], jsonValue)
+}
+
+func TestEncoder_Functions(t *testing.T) {
+	tempDir := t.TempDir()
+	rdbFile := filepath.Join(tempDir, "functions.rdb")
+
+	encoder, err := NewFileEncoder(rdbFile, version)
+	require.NoError(t, err)
+
+	require.NoError(t, encoder.Begin())
+
+	libraryCode := `
+		#!lua name=mylib
+	
+		local function my_hset(keys, args)
+		  local hash = keys[1]
+		  local time = redis.call('TIME')[1]
+		  return redis.call('HSET', hash, '_last_modified_', time, unpack(args))
+		end
+		
+		redis.register_function('my_hset', my_hset)
+	`
+
+	err = encoder.WriteLibrary(libraryCode)
+	require.NoError(t, err)
+
+	require.NoError(t, encoder.Close())
+
+	db := newDummyDB()
+	err = ReadFile(filepath.Join(rdbFile), db)
+	require.NoError(t, err)
+
+	require.Len(t, db.libraries, 1)
+	require.Equal(t, db.libraries[0], libraryCode)
 }

--- a/file_reader.go
+++ b/file_reader.go
@@ -217,11 +217,11 @@ func readFile(buf buffer, handler FileHandler, maxLz77StrLen uint64) error {
 		case typeOpCodeFunctionPreGA:
 			return errors.New("pre-release function format not supported")
 		case typeOpCodeFunction2:
-			if !handler.AllowPartialRead() {
-				return errors.New("restoring function payload is not supported when the partial restore is not allowed")
+			payload, err := reader.ReadString() // function payload
+			if err != nil {
+				return err
 			}
-
-			_, err = reader.ReadString() // function payload
+			err = handler.HandleLibrary(payload)
 			if err != nil {
 				return err
 			}

--- a/file_reader_test.go
+++ b/file_reader_test.go
@@ -24,6 +24,7 @@ type dummyDB struct {
 	listEntriesRead   map[string]uint64
 	zsetEntriesRead   map[string]uint64
 	streamEntriesRead map[string]uint64
+	libraries         []string
 }
 
 func newDummyDB() *dummyDB {
@@ -42,6 +43,7 @@ func newDummyDB() *dummyDB {
 		zsetEntriesRead:   make(map[string]uint64),
 		streamEntriesRead: make(map[string]uint64),
 		hashExpireTimes:   make(map[string]map[string]time.Time),
+		libraries:         make([]string, 0),
 	}
 }
 
@@ -184,6 +186,11 @@ func (db *dummyDB) HashWithExpEntryHandler(key string) func(field string, value 
 	}
 }
 
+func (db *dummyDB) HandleLibrary(code string) error {
+	db.libraries = append(db.libraries, code)
+	return nil
+}
+
 var dumpsPath = filepath.Join("testdata", "dumps")
 
 func TestFileReader_PreV5_withoutCRC(t *testing.T) {
@@ -270,11 +277,9 @@ func TestFileReader_withFreqInfo(t *testing.T) {
 func TestFileReader_function(t *testing.T) {
 	db := newDummyDB()
 	err := ReadFile(filepath.Join(dumpsPath, "function.rdb"), db)
-	require.ErrorContains(t, err, "restoring function payload is not supported when the partial restore is not allowed")
-
-	db.partialRead = true
-	err = ReadFile(filepath.Join(dumpsPath, "function.rdb"), db)
 	require.NoError(t, err)
+
+	require.Len(t, db.libraries, 1)
 }
 
 func TestFileReader_expireTimeSec(t *testing.T) {

--- a/handler.go
+++ b/handler.go
@@ -47,6 +47,9 @@ type ValueHandler interface {
 
 	// returned function is called for the each read hash enty with expiration info  for the key.
 	HashWithExpEntryHandler(key string) func(field string, value string, ttl time.Time) error
+
+	// called when the a function code is read
+	HandleLibrary(code string) error
 }
 
 // FileHandler is an extension of ValueHandler, which can handle RDB objects
@@ -54,6 +57,7 @@ type ValueHandler interface {
 type FileHandler interface {
 	ValueHandler
 	HandleExpireTime(key string, expireTime time.Duration)
+	HandleLibrary(code string) error
 }
 
 // nopHandler is used to ignore the RDB objects read so that
@@ -127,5 +131,9 @@ func (nopHandler) HandleExpireTime(key string, expireTime time.Duration) {
 }
 
 func (h nopHandler) HashWithExpEntryHandler(key string) func(field string, value string, ttl time.Time) error {
+	return nil
+}
+
+func (nopHandler) HandleLibrary(code string) error {
 	return nil
 }

--- a/verify.go
+++ b/verify.go
@@ -84,6 +84,7 @@ type VerifyReaderOptions struct {
 	MaxEntrySize       int
 	MaxKeySize         int
 	MaxStreamPELSize   int
+	MaxLibrarySize     int
 	AllowPartialVerify bool
 	RequireStrictEOF   bool
 }
@@ -104,6 +105,10 @@ func (o *VerifyReaderOptions) maybeSetDefaults() {
 	if o.MaxStreamPELSize <= 0 {
 		o.MaxStreamPELSize = defaultMaxStreamPELSize
 	}
+
+	if o.MaxLibrarySize <= 0 {
+		o.MaxLibrarySize = defaultMaxLibrarySize
+	}
 }
 
 // VerifyReader verifies that the given RDB reader is not corrupt,
@@ -115,6 +120,7 @@ func VerifyReader(r io.Reader, opts VerifyReaderOptions) error {
 		maxEntrySize:       opts.MaxEntrySize,
 		maxKeySize:         opts.MaxKeySize,
 		maxStreamPELSize:   opts.MaxStreamPELSize,
+		maxLibrarySize:     opts.MaxLibrarySize,
 		allowPartialVerify: opts.AllowPartialVerify,
 		requireStrictEOF:   opts.RequireStrictEOF,
 	}

--- a/verify.go
+++ b/verify.go
@@ -12,6 +12,7 @@ var defaultMaxDataSize = 256 << 20  // 256 MB
 var defaultMaxEntrySize = 100 << 20 // 100 MB
 var defaultMaxKeySize = 32 << 10    // 32 KB
 var defaultMaxStreamPELSize = 1000
+var defaultMaxLibrarySize = 100 << 20 // 100 MB
 
 const maxStreamStrSize = math.MaxUint32
 
@@ -20,6 +21,7 @@ type VerifyFileOptions struct {
 	MaxEntrySize       int
 	MaxKeySize         int
 	MaxStreamPELSize   int
+	MaxLibrarySize     int
 	AllowPartialVerify bool
 	RequireStrictEOF   bool
 }
@@ -40,6 +42,10 @@ func (o *VerifyFileOptions) maybeSetDefaults() {
 	if o.MaxStreamPELSize <= 0 {
 		o.MaxStreamPELSize = defaultMaxStreamPELSize
 	}
+
+	if o.MaxLibrarySize <= 0 {
+		o.MaxLibrarySize = defaultMaxLibrarySize
+	}
 }
 
 // VerifyFile verifies that the given RDB file is not corrupt,
@@ -51,6 +57,7 @@ func VerifyFile(path string, opts VerifyFileOptions) error {
 		maxEntrySize:       opts.MaxEntrySize,
 		maxKeySize:         opts.MaxKeySize,
 		maxStreamPELSize:   opts.MaxStreamPELSize,
+		maxLibrarySize:     opts.MaxLibrarySize,
 		allowPartialVerify: opts.AllowPartialVerify,
 		requireStrictEOF:   opts.RequireStrictEOF,
 	}
@@ -141,8 +148,9 @@ func VerifyValue(payload []byte, opts VerifyValueOptions) error {
 		maxStreamPELSize: opts.MaxStreamPELSize,
 		// We don't care about the values below, as they don't
 		// really apply to RDB values.
-		maxDataSize: math.MaxInt,
-		maxKeySize:  math.MaxInt,
+		maxDataSize:    math.MaxInt,
+		maxKeySize:     math.MaxInt,
+		maxLibrarySize: math.MaxInt,
 	}
 
 	return readValue("", payload, v, uint64(opts.MaxEntrySize))
@@ -168,6 +176,10 @@ func errMaxStreamStrSizeExceeded(current int, limit int) error {
 	return fmt.Errorf("max stream string item size is exceeded. current: %d, limit: %d", current, limit)
 }
 
+func errMaxLibrarySizeExceeded(current int, limit int) error {
+	return fmt.Errorf("max library size is exceeded. current: %d, limit: %d", current, limit)
+}
+
 type verifier struct {
 	maxDataSize        int
 	maxEntrySize       int
@@ -176,6 +188,8 @@ type verifier struct {
 	allowPartialVerify bool
 	requireStrictEOF   bool
 	dataSize           int
+	librarySize        int
+	maxLibrarySize     int
 }
 
 func (v *verifier) HandleString(key string, value string) error {
@@ -473,4 +487,13 @@ func (v *verifier) HandleZsetEnding(key string, entriesRead uint64) {
 }
 
 func (v *verifier) HandleStreamEnding(key string, entriesRead uint64) {
+}
+
+func (v *verifier) HandleLibrary(code string) error {
+	v.librarySize += len(code)
+	if v.librarySize > v.maxLibrarySize {
+		return errMaxLibrarySizeExceeded(v.librarySize, v.maxLibrarySize)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR adds support for serializing and deserializing Redis Functions in the RDB format. 

It also includes data size verify logic to prevent loading large function payloads to memory when reading an RDB file.