### PR TITLE
Fix RDB key expiry timestamps

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -317,7 +317,7 @@ func (s *FileEncoder) writeExpiry(expiry time.Time) error {
 	if err := s.writer.WriteByte(byte(typeOpCodeExpireTimeMS)); err != nil {
 		return err
 	}
-	msTimestamp := uint64(time.Until(expiry).Milliseconds())
+	msTimestamp := uint64(expiry.UnixMilli())
 	if err := s.writer.WriteUint64(msTimestamp); err != nil {
 		return err
 	}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -72,10 +72,33 @@ func TestEncoder_String(t *testing.T) {
 	for _, tc := range tests {
 		require.Equal(t, db.strings[tc.key], tc.value)
 		if !tc.expiry.IsZero() {
-			require.WithinDuration(t, time.Now().Add(db.expireTimes[tc.key]), tc.expiry, time.Second*30)
+			require.WithinDuration(t, db.expireTimes[tc.key], tc.expiry, time.Second)
 		}
 	}
 
+}
+
+func TestEncoder_StringExpiryTime(t *testing.T) {
+	rdbFile := filepath.Join(t.TempDir(), "string-expiry.rdb")
+
+	encoder, err := NewFileEncoder(rdbFile, version)
+	require.NoError(t, err)
+	require.NoError(t, encoder.Begin())
+
+	key := "with-expiry"
+	value := "expires later"
+	expiry := time.Date(2030, time.April, 13, 9, 37, 49, int(time.Millisecond), time.UTC)
+	err = encoder.WriteStringEntry(key, value, expiry)
+	require.NoError(t, err)
+	require.NoError(t, encoder.Close())
+
+	db := newDummyDB()
+	err = ReadFile(rdbFile, db)
+	require.NoError(t, err)
+
+	require.Equal(t, value, db.strings[key])
+	expireTime := db.expireTimes[key]
+	require.True(t, expiry.Equal(expireTime), "Expected expiry time to be %s, got %s", expiry, expireTime)
 }
 
 func TestEncoder_List(t *testing.T) {

--- a/file_reader.go
+++ b/file_reader.go
@@ -107,7 +107,7 @@ func readFile(buf buffer, handler FileHandler, maxLz77StrLen uint64) error {
 	handler0 := handler
 
 	var hasExpireTime bool
-	var expireTime time.Duration
+	var expireTime time.Time
 	for {
 		t, err := reader.ReadType()
 		if err != nil {
@@ -161,7 +161,7 @@ func readFile(buf buffer, handler FileHandler, maxLz77StrLen uint64) error {
 				return err
 			}
 			hasExpireTime = true
-			expireTime = time.Duration(t) * time.Second
+			expireTime = time.Unix(int64(t), 0)
 		case typeOpCodeExpireTimeMS:
 			t, err := reader.readUint64()
 			if err != nil {
@@ -169,7 +169,7 @@ func readFile(buf buffer, handler FileHandler, maxLz77StrLen uint64) error {
 			}
 
 			hasExpireTime = true
-			expireTime = time.Duration(t) * time.Millisecond
+			expireTime = time.UnixMilli(int64(t))
 		case typeOpCodeResizeDB:
 			_, _, err = reader.readLen() // db size
 			if err != nil {
@@ -240,7 +240,7 @@ func readFile(buf buffer, handler FileHandler, maxLz77StrLen uint64) error {
 	}
 }
 
-func readObject(reader *valueReader, handler FileHandler, t Type, hasExpireTime bool, expireTime time.Duration) error {
+func readObject(reader *valueReader, handler FileHandler, t Type, hasExpireTime bool, expireTime time.Time) error {
 	key, err := reader.ReadString()
 	if err != nil {
 		return err

--- a/file_reader_test.go
+++ b/file_reader_test.go
@@ -19,7 +19,7 @@ type dummyDB struct {
 	modules           map[string]string
 	streamEntries     map[string][]StreamEntry
 	streamGroups      map[string][]StreamConsumerGroup
-	expireTimes       map[string]time.Duration
+	expireTimes       map[string]time.Time
 	hashExpireTimes   map[string]map[string]time.Time
 	listEntriesRead   map[string]uint64
 	zsetEntriesRead   map[string]uint64
@@ -38,7 +38,7 @@ func newDummyDB() *dummyDB {
 		modules:           make(map[string]string),
 		streamEntries:     make(map[string][]StreamEntry),
 		streamGroups:      make(map[string][]StreamConsumerGroup),
-		expireTimes:       make(map[string]time.Duration),
+		expireTimes:       make(map[string]time.Time),
 		listEntriesRead:   make(map[string]uint64),
 		zsetEntriesRead:   make(map[string]uint64),
 		streamEntriesRead: make(map[string]uint64),
@@ -159,7 +159,7 @@ func (db *dummyDB) HandleStreamEnding(key string, entriesRead uint64) {
 	db.streamEntriesRead[key] = entriesRead
 }
 
-func (db *dummyDB) HandleExpireTime(key string, expireTime time.Duration) {
+func (db *dummyDB) HandleExpireTime(key string, expireTime time.Time) {
 	db.expireTimes[key] = expireTime
 }
 
@@ -257,7 +257,7 @@ func TestFileReader_withIdleInfo(t *testing.T) {
 
 	expected := newDummyDB()
 	expected.strings["up"] = "stash"
-	expected.expireTimes["up"] = time.Duration(1694542150330000000)
+	expected.expireTimes["up"] = time.Unix(0, 1694542150330000000)
 
 	require.Equal(t, expected, db)
 }
@@ -269,7 +269,7 @@ func TestFileReader_withFreqInfo(t *testing.T) {
 
 	expected := newDummyDB()
 	expected.strings["up"] = "stash"
-	expected.expireTimes["up"] = time.Duration(1694542238686000000)
+	expected.expireTimes["up"] = time.Unix(0, 1694542238686000000)
 
 	require.Equal(t, expected, db)
 }
@@ -289,7 +289,7 @@ func TestFileReader_expireTimeSec(t *testing.T) {
 
 	expected := newDummyDB()
 	expected.strings["up"] = "stash"
-	expected.expireTimes["up"] = time.Duration(2325035706000000000)
+	expected.expireTimes["up"] = time.Unix(0, 2325035706000000000)
 
 	require.Equal(t, expected, db)
 }

--- a/handler.go
+++ b/handler.go
@@ -45,8 +45,8 @@ type ValueHandler interface {
 	// with the name and the number of entries read.
 	HandleStreamEnding(key string, entriesRead uint64)
 
-	// returned function is called for the each read hash enty with expiration info  for the key.
-	HashWithExpEntryHandler(key string) func(field string, value string, ttl time.Time) error
+	// returned function is called for each read hash entry with expiration info for the key.
+	HashWithExpEntryHandler(key string) func(field string, value string, exp time.Time) error
 
 	// called when the a function code is read
 	HandleLibrary(code string) error
@@ -56,7 +56,8 @@ type ValueHandler interface {
 // and their expiration information from RDB files.
 type FileHandler interface {
 	ValueHandler
-	HandleExpireTime(key string, expireTime time.Duration)
+	// called when a key expiration timestamp is read.
+	HandleExpireTime(key string, expireTime time.Time)
 	HandleLibrary(code string) error
 }
 
@@ -127,10 +128,10 @@ func (nopHandler) StreamGroupHandler(key string) func(group StreamConsumerGroup)
 func (nopHandler) HandleStreamEnding(key string, entriesRead uint64) {
 }
 
-func (nopHandler) HandleExpireTime(key string, expireTime time.Duration) {
+func (nopHandler) HandleExpireTime(key string, expireTime time.Time) {
 }
 
-func (h nopHandler) HashWithExpEntryHandler(key string) func(field string, value string, ttl time.Time) error {
+func (h nopHandler) HashWithExpEntryHandler(key string) func(field string, value string, exp time.Time) error {
 	return nil
 }
 

--- a/verify.go
+++ b/verify.go
@@ -483,7 +483,7 @@ func (v *verifier) RequireStrictEOF() bool {
 	return v.requireStrictEOF
 }
 
-func (v *verifier) HandleExpireTime(key string, expireTime time.Duration) {
+func (v *verifier) HandleExpireTime(key string, expireTime time.Time) {
 }
 
 func (v *verifier) HandleListEnding(key string, entriesRead uint64) {


### PR DESCRIPTION
Stored and read key expirations as absolute Unix timestamps instead of relative durations. Updated `FileHandler` expiry handling to use `time.Time`.